### PR TITLE
add catalog-triples to meta-models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>3.2.2</version>
+      <version>3.2.4</version>
       <relativePath/>
     </parent>
 
@@ -29,8 +29,8 @@
         <maven.exec.skip>false</maven.exec.skip>
         <!--end standard properties-->
 
-        <kotlin.version>1.9.22</kotlin.version>
-        <testcontainers.version>1.19.5</testcontainers.version>
+        <kotlin.version>1.9.23</kotlin.version>
+        <testcontainers.version>1.19.7</testcontainers.version>
         <jena.version>4.10.0</jena.version>
     </properties>
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
-            <version>1.7.3</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
@@ -126,13 +126,13 @@
         <dependency>
             <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
-            <version>5.2.1</version>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>3.3.1</version>
+            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -186,7 +186,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -234,7 +234,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.12</version>
                 <executions>
                     <execution>
                         <id>before-unit-test-execution</id>

--- a/src/main/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterActivity.kt
+++ b/src/main/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterActivity.kt
@@ -87,7 +87,6 @@ class HarvesterActivity(
                         .awaitAll()
                         .filterNotNull()
                         .also { updateService.updateMetaData() }
-                        .also { updateService.updateUnionModel() }
                         .also {
                             if (params.harvestAllModels()) LOGGER.debug("completed harvest with parameters $params, force update: $forceUpdate")
                             else LOGGER.debug("completed harvest of all catalogs, force update: $forceUpdate")

--- a/src/main/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterActivity.kt
+++ b/src/main/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterActivity.kt
@@ -86,6 +86,7 @@ class HarvesterActivity(
                         }
                         .awaitAll()
                         .filterNotNull()
+                        .also { updateService.updateMetaData() }
                         .also { updateService.updateUnionModel() }
                         .also {
                             if (params.harvestAllModels()) LOGGER.debug("completed harvest with parameters $params, force update: $forceUpdate")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,15 +53,15 @@ application:
 spring:
   config.activate.on-profile: contract-test
   security.oauth2.resourceserver.jwt:
-    jwk-set-uri: http://localhost:5000/auth/realms/fdk/protocol/openid-connect/certs
-    issuer-uri: http://localhost:5000/auth/realms/fdk
+    jwk-set-uri: http://localhost:5050/auth/realms/fdk/protocol/openid-connect/certs
+    issuer-uri: http://localhost:5050/auth/realms/fdk
   rabbitmq:
     host: localhost
     port: 5001
     username: admin
     password: admin
 application:
-  informationModelUri: http://localhost:5000/informationmodels
-  catalogUri: http://localhost:5000/catalogs
-  harvestAdminRootUrl: http://localhost:5000
-fuseki.unionGraphUri: http://localhost:5000/fuseki/harvested?graph=https://informationmodels.fellesdatakatalog.digdir.no
+  informationModelUri: http://localhost:5050/informationmodels
+  catalogUri: http://localhost:5050/catalogs
+  harvestAdminRootUrl: http://localhost:5050
+fuseki.unionGraphUri: http://localhost:5050/fuseki/harvested?graph=https://informationmodels.fellesdatakatalog.digdir.no

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/contract/InformationModelTest.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/contract/InformationModelTest.kt
@@ -6,6 +6,7 @@ import no.fdk.fdk_informationmodel_harvester.utils.TestResponseReader
 import no.fdk.fdk_informationmodel_harvester.utils.apiGet
 import org.apache.jena.riot.Lang
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
@@ -24,7 +25,7 @@ class InformationModelTest: ApiTestContext() {
     @Test
     fun findSpecific() {
         val response = apiGet("/informationmodels/$INFO_MODEL_ID_0?catalogrecords=true", "application/rdf+json", port)
-        Assumptions.assumeTrue(HttpStatus.OK.value() == response["status"])
+        assertEquals(HttpStatus.OK.value(), response["status"])
 
         val notExpected = responseReader.parseFile("no_meta_model_0.ttl", "TURTLE")
         val responseModel = responseReader.parseResponse(response["body"] as String, "RDF/JSON")
@@ -35,7 +36,7 @@ class InformationModelTest: ApiTestContext() {
     @Test
     fun findSpecificExcludeRecords() {
         val response = apiGet("/informationmodels/$INFO_MODEL_ID_0", "application/trig", port)
-        Assumptions.assumeTrue(HttpStatus.OK.value() == response["status"])
+        assertEquals(HttpStatus.OK.value(), response["status"])
 
         val expected = responseReader.parseFile("no_meta_model_0.ttl", "TURTLE")
         val responseModel = responseReader.parseResponse(response["body"] as String, Lang.TRIG.name)
@@ -46,7 +47,7 @@ class InformationModelTest: ApiTestContext() {
     @Test
     fun idDoesNotExist() {
         val response = apiGet("/dataservices/123", "text/turtle", port)
-        Assertions.assertEquals(HttpStatus.NOT_FOUND.value(), response["status"])
+        assertEquals(HttpStatus.NOT_FOUND.value(), response["status"])
     }
 
 }

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterTest.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterTest.kt
@@ -46,15 +46,15 @@ class HarvesterTest {
 
         whenever(adapter.getInformationModels(TEST_HARVEST_SOURCE))
             .thenReturn(harvested)
-        whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/$CATALOG_ID_0"))
+        whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/$CATALOG_ID_0"))
             .thenReturn(listOf(INFO_MODEL_DBO_0))
         whenever(turtleService.findInformationModel(INFO_MODEL_ID_0, true))
             .thenReturn(savedInfoModel)
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE, TEST_HARVEST_DATE, false)
 
@@ -99,7 +99,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-05 15:15:39 +0200",
@@ -123,7 +123,7 @@ class HarvesterTest {
 
         whenever(adapter.getInformationModels(TEST_HARVEST_SOURCE_2))
             .thenReturn(harvested)
-        whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/$CATALOG_ID_2"))
+        whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/$CATALOG_ID_2"))
             .thenReturn(listOf(INFO_MODEL_META_2, INFO_MODEL_META_3))
         whenever(turtleService.findInformationModel(INFO_MODEL_META_2.fdkId, true))
             .thenReturn(savedModel2)
@@ -131,9 +131,9 @@ class HarvesterTest {
             .thenReturn(savedModel3)
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE_2, TEST_HARVEST_DATE, false)
 
@@ -191,7 +191,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest2",
-            url="http://localhost:5000/harvest2",
+            url="http://localhost:5050/harvest2",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-05 15:15:39 +0200",
@@ -217,9 +217,9 @@ class HarvesterTest {
             .thenReturn(harvested)
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE, TEST_HARVEST_DATE, false)
 
@@ -231,7 +231,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-05 15:15:39 +0200",
@@ -251,9 +251,9 @@ class HarvesterTest {
             .thenReturn(harvested)
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE, TEST_HARVEST_DATE, true)
 
@@ -265,7 +265,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-05 15:15:39 +0200",
@@ -285,13 +285,13 @@ class HarvesterTest {
 
         val catalogDiffTurtle = responseReader.readFile("harvest_response_0_catalog_diff.ttl")
 
-        whenever(turtleService.findOne("http://localhost:5000/harvest"))
+        whenever(turtleService.findOne("http://localhost:5050/harvest"))
             .thenReturn(catalogDiffTurtle)
         whenever(catalogRepository.findById(CATALOG_DBO_0.uri))
             .thenReturn(Optional.of(CATALOG_DBO_0))
         whenever(modelRepository.findById(INFO_MODEL_DBO_0.uri))
             .thenReturn(Optional.of(INFO_MODEL_DBO_0))
-        whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/$CATALOG_ID_0"))
+        whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/$CATALOG_ID_0"))
             .thenReturn(listOf(INFO_MODEL_DBO_0))
         whenever(turtleService.findInformationModel(INFO_MODEL_ID_0, true))
             .thenReturn(responseReader.readFile("model_0.ttl"))
@@ -299,9 +299,9 @@ class HarvesterTest {
             .thenReturn(responseReader.readFile("no_meta_model_0.ttl"))
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val expectedCatalogDBO = CATALOG_DBO_0.copy(modified = NEW_TEST_HARVEST_DATE.timeInMillis)
         val expectedCatalogTurtle = responseReader.parseFile("catalog_0_catalog_diff.ttl", "TURTLE")
@@ -312,7 +312,7 @@ class HarvesterTest {
 
         argumentCaptor<String, String>().apply {
             verify(turtleService, times(1)).saveOne(first.capture(), second.capture())
-            assertEquals("http://localhost:5000/harvest", first.firstValue)
+            assertEquals("http://localhost:5050/harvest", first.firstValue)
             Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.firstValue, Lang.TURTLE), harvestedModel, "onlyCatalogMetaUpdatedWhenOnlyCatalogDataChangedFromDB-harvested"))
         }
 
@@ -339,7 +339,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-15 13:52:16 +0200",
@@ -358,9 +358,9 @@ class HarvesterTest {
             .thenReturn(responseReader.readFile("harvest_error_response.ttl"))
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE, TEST_HARVEST_DATE, false)
 
@@ -372,7 +372,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=true,
             errorMessage = "[line: 1, col: 1 ] Undefined prefix: digdir",
@@ -391,13 +391,13 @@ class HarvesterTest {
             .thenReturn(harvested)
         whenever(turtleService.findOne(TEST_HARVEST_SOURCE.url!!))
             .thenReturn(old)
-        whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/$CATALOG_ID_0"))
+        whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/$CATALOG_ID_0"))
             .thenReturn(listOf(INFO_MODEL_DBO_0))
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE, TEST_HARVEST_DATE, false)
 
@@ -408,7 +408,7 @@ class HarvesterTest {
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-05 15:15:39 +0200",
@@ -430,19 +430,19 @@ class HarvesterTest {
             .thenReturn(harvested)
         whenever(turtleService.findOne(TEST_HARVEST_SOURCE.url!!))
             .thenReturn(old)
-        whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/$CATALOG_ID_0"))
+        whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/$CATALOG_ID_0"))
             .thenReturn(listOf(INFO_MODEL_DBO_0))
 
         whenever(valuesMock.catalogUri)
-            .thenReturn("http://localhost:5000/catalogs")
+            .thenReturn("http://localhost:5050/catalogs")
         whenever(valuesMock.informationModelUri)
-            .thenReturn("http://localhost:5000/informationmodels")
+            .thenReturn("http://localhost:5050/informationmodels")
 
         val report = harvester.harvestInformationModelCatalog(TEST_HARVEST_SOURCE, TEST_HARVEST_DATE, false)
 
         val expectedReport = HarvestReport(
             id="harvest",
-            url="http://localhost:5000/harvest",
+            url="http://localhost:5050/harvest",
             dataType="informationmodel",
             harvestError=false,
             startTime = "2020-10-05 15:15:39 +0200",

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterTest.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/harvester/HarvesterTest.kt
@@ -82,19 +82,17 @@ class HarvesterTest {
         val model0NoMeta = responseReader.parseFile("no_meta_model_0.ttl", "TURTLE")
 
         argumentCaptor<String, String, Boolean>().apply {
-            verify(turtleService, times(2)).saveCatalog(first.capture(), second.capture(), third.capture())
-            assertEquals(listOf(CATALOG_ID_0, CATALOG_ID_0), first.allValues)
+            verify(turtleService, times(1)).saveCatalog(first.capture(), second.capture(), third.capture())
+            assertEquals(listOf(CATALOG_ID_0), first.allValues)
             Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.firstValue, Lang.TURTLE), catalog0NoMeta, "harvestDataSourceSavedWhenDBIsEmpty-no-record-catalog"))
-            Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.secondValue, Lang.TURTLE), catalog0, "harvestDataSourceSavedWhenDBIsEmpty-record-catalog"))
-            assertEquals(listOf(false, true), third.allValues)
+            assertEquals(listOf(false), third.allValues)
         }
 
         argumentCaptor<String, String, Boolean>().apply {
-            verify(turtleService, times(2)).saveInformationModel(first.capture(), second.capture(), third.capture())
-            assertEquals(listOf(INFO_MODEL_ID_0, INFO_MODEL_ID_0), first.allValues)
+            verify(turtleService, times(1)).saveInformationModel(first.capture(), second.capture(), third.capture())
+            assertEquals(listOf(INFO_MODEL_ID_0), first.allValues)
             Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.firstValue, Lang.TURTLE), model0NoMeta, "harvestDataSourceSavedWhenDBIsEmpty-record-model"))
-            Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.secondValue, Lang.TURTLE), model0, "harvestDataSourceSavedWhenDBIsEmpty-no-record-model"))
-            assertEquals(listOf(false, true), third.allValues)
+            assertEquals(listOf(false), third.allValues)
         }
 
         val expectedReport = HarvestReport(
@@ -163,30 +161,24 @@ class HarvesterTest {
         val modelNoMeta3 = responseReader.parseFile("no_meta_model_3.ttl", "TURTLE")
 
         argumentCaptor<String, String, Boolean>().apply {
-            verify(turtleService, times(2)).saveCatalog(first.capture(), second.capture(), third.capture())
-            assertEquals(listOf(CATALOG_DBO_2.fdkId, CATALOG_DBO_2.fdkId), first.allValues)
+            verify(turtleService, times(1)).saveCatalog(first.capture(), second.capture(), third.capture())
+            assertEquals(listOf(CATALOG_DBO_2.fdkId), first.allValues)
             Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.firstValue, Lang.TURTLE), catalogNoMeta2, "sourceWithCodeListIsParsedCorrectly-no-record-catalog"))
-            Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.secondValue, Lang.TURTLE), catalog2, "sourceWithCodeListIsParsedCorrectly-record-catalog"))
-            assertEquals(listOf(false, true), third.allValues)
+            assertEquals(listOf(false), third.allValues)
         }
 
         argumentCaptor<String, String, Boolean>().apply {
-            verify(turtleService, times(4)).saveInformationModel(first.capture(), second.capture(), third.capture())
+            verify(turtleService, times(2)).saveInformationModel(first.capture(), second.capture(), third.capture())
             if (first.firstValue == INFO_MODEL_META_2.fdkId) {
-                assertEquals(listOf(INFO_MODEL_META_2.fdkId, INFO_MODEL_META_2.fdkId, INFO_MODEL_META_3.fdkId, INFO_MODEL_META_3.fdkId), first.allValues)
+                assertEquals(listOf(INFO_MODEL_META_2.fdkId, INFO_MODEL_META_3.fdkId), first.allValues)
                 Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[0], Lang.TURTLE), modelNoMeta2, "sourceWithCodeListIsParsedCorrectly-model0"))
-                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[1], Lang.TURTLE), model2, "sourceWithCodeListIsParsedCorrectly-model1"))
-                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[2], Lang.TURTLE), modelNoMeta3, "sourceWithCodeListIsParsedCorrectly-model2"))
-                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[3], Lang.TURTLE), model3, "sourceWithCodeListIsParsedCorrectly-model3"))
+                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[1], Lang.TURTLE), modelNoMeta3, "sourceWithCodeListIsParsedCorrectly-model2"))
             } else {
-                assertEquals(listOf(INFO_MODEL_META_3.fdkId, INFO_MODEL_META_3.fdkId, INFO_MODEL_META_2.fdkId, INFO_MODEL_META_2.fdkId), first.allValues)
+                assertEquals(listOf(INFO_MODEL_META_3.fdkId, INFO_MODEL_META_2.fdkId), first.allValues)
                 Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[0], Lang.TURTLE), modelNoMeta3, "sourceWithCodeListIsParsedCorrectly-model4"))
-                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[1], Lang.TURTLE), model3, "sourceWithCodeListIsParsedCorrectly-model5"))
-                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[2], Lang.TURTLE), modelNoMeta2, "sourceWithCodeListIsParsedCorrectly-model6"))
-                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[3], Lang.TURTLE), model2, "sourceWithCodeListIsParsedCorrectly-model7"))
-
+                Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.allValues[1], Lang.TURTLE), modelNoMeta2, "sourceWithCodeListIsParsedCorrectly-model6"))
             }
-            assertEquals(listOf(false, true, false, true), third.allValues)
+            assertEquals(listOf(false, false), third.allValues)
         }
 
         val expectedReport = HarvestReport(
@@ -260,8 +252,8 @@ class HarvesterTest {
         verify(turtleService, times(1)).saveOne(any(), any())
         verify(catalogRepository, times(1)).save(any())
         verify(modelRepository, times(1)).save(any())
-        verify(turtleService, times(2)).saveCatalog(any(), any(), any())
-        verify(turtleService, times(2)).saveInformationModel(any(), any(), any())
+        verify(turtleService, times(1)).saveCatalog(any(), any(), any())
+        verify(turtleService, times(1)).saveInformationModel(any(), any(), any())
 
         val expectedReport = HarvestReport(
             id="harvest",
@@ -326,11 +318,10 @@ class HarvesterTest {
         }
 
         argumentCaptor<String, String, Boolean>().apply {
-            verify(turtleService, times(2)).saveCatalog(first.capture(), second.capture(), third.capture())
-            assertEquals(listOf(CATALOG_DBO_0.fdkId, CATALOG_DBO_0.fdkId), first.allValues)
+            verify(turtleService, times(1)).saveCatalog(first.capture(), second.capture(), third.capture())
+            assertEquals(listOf(CATALOG_DBO_0.fdkId), first.allValues)
             Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.firstValue, Lang.TURTLE), expectedNoMetaCatalog, "onlyCatalogMetaUpdatedWhenOnlyCatalogDataChangedFromDB-no-record-catalog"))
-            Assertions.assertTrue(checkIfIsomorphicAndPrintDiff(parseRDFResponse(second.secondValue, Lang.TURTLE), expectedCatalogTurtle, "onlyCatalogMetaUpdatedWhenOnlyCatalogDataChangedFromDB-record-catalog"))
-            assertEquals(listOf(false, true), third.allValues)
+            assertEquals(listOf(false), third.allValues)
         }
 
         argumentCaptor<String, String, Boolean>().apply {

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/service/UpdateServiceTest.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/service/UpdateServiceTest.kt
@@ -35,9 +35,9 @@ class UpdateServiceTest {
         fun catalogRecordsIsRecreatedFromMetaDBO() {
             whenever(catalogRepository.findAll())
                 .thenReturn(listOf(CATALOG_DBO_0, CATALOG_DBO_1))
-            whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/${CATALOG_DBO_0.fdkId}"))
+            whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/${CATALOG_DBO_0.fdkId}"))
                 .thenReturn(listOf(INFO_MODEL_DBO_0))
-            whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/${CATALOG_DBO_1.fdkId}"))
+            whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/${CATALOG_DBO_1.fdkId}"))
                 .thenReturn(listOf(INFO_MODEL_DBO_1))
             whenever(turtleService.findCatalog(CATALOG_ID_0, false))
                 .thenReturn(responseReader.readFile("no_meta_catalog_0.ttl"))
@@ -50,9 +50,9 @@ class UpdateServiceTest {
 
 
             whenever(valuesMock.catalogUri)
-                .thenReturn("http://localhost:5000/catalogs")
+                .thenReturn("http://localhost:5050/catalogs")
             whenever(valuesMock.informationModelUri)
-                .thenReturn("http://localhost:5000/informationmodels")
+                .thenReturn("http://localhost:5050/informationmodels")
 
             updateService.updateMetaData()
 
@@ -84,7 +84,7 @@ class UpdateServiceTest {
         fun updateIsSkippedIfNotActuallyPresentInCatalog() {
             whenever(catalogRepository.findAll())
                 .thenReturn(listOf(CATALOG_DBO_0))
-            whenever(modelRepository.findAllByIsPartOf("http://localhost:5000/catalogs/${CATALOG_ID_0}"))
+            whenever(modelRepository.findAllByIsPartOf("http://localhost:5050/catalogs/${CATALOG_ID_0}"))
                 .thenReturn(listOf(INFO_MODEL_DBO_0, INFO_MODEL_DBO_1))
             whenever(turtleService.findCatalog(CATALOG_ID_0, false))
                 .thenReturn(responseReader.readFile("harvest_response_0_no_models.ttl"))
@@ -94,9 +94,9 @@ class UpdateServiceTest {
                 .thenReturn(responseReader.readFile("no_meta_model_1.ttl"))
 
             whenever(valuesMock.catalogUri)
-                .thenReturn("http://localhost:5000/catalogs")
+                .thenReturn("http://localhost:5050/catalogs")
             whenever(valuesMock.informationModelUri)
-                .thenReturn("http://localhost:5000/informationmodels")
+                .thenReturn("http://localhost:5050/informationmodels")
 
             updateService.updateMetaData()
 

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/ApiTestContainer.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/ApiTestContainer.kt
@@ -1,6 +1,6 @@
 package no.fdk.fdk_informationmodel_harvester.utils
 
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.slf4j.LoggerFactory
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.boot.test.web.server.LocalServerPort
@@ -17,7 +17,7 @@ abstract class ApiTestContext {
     @LocalServerPort
     var port: Int = 0
 
-    @BeforeAll
+    @BeforeEach
     fun waitForHarvest() {
         var apiReady = harvestCompleted(port)
         while (!apiReady) {

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/ApiTestContainer.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/ApiTestContainer.kt
@@ -51,7 +51,7 @@ abstract class ApiTestContext {
             mongoContainer.start()
 
             try {
-                val con = URL("http://localhost:5000/ping").openConnection() as HttpURLConnection
+                val con = URL("http://localhost:5050/ping").openConnection() as HttpURLConnection
                 con.connect()
                 if (con.responseCode != 200) {
                     logger.debug("Ping to mock server failed")

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/DatabaseData.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/DatabaseData.kt
@@ -14,7 +14,7 @@ val CATALOG_DBO_0 = CatalogMeta(
 val INFO_MODEL_DBO_0 = InformationModelMeta(
     uri = "${DIGDIR_PREFIX}PersonOgEnhet",
     fdkId = INFO_MODEL_ID_0,
-    isPartOf = "http://localhost:5000/catalogs/$CATALOG_ID_0",
+    isPartOf = "http://localhost:5050/catalogs/$CATALOG_ID_0",
     issued = TEST_HARVEST_DATE.timeInMillis,
     modified = TEST_HARVEST_DATE.timeInMillis
 )
@@ -28,7 +28,7 @@ val CATALOG_DBO_1 = CatalogMeta(
 val INFO_MODEL_DBO_1 = InformationModelMeta(
     uri = "${DIGDIR_PREFIX}AdresseModell",
     fdkId = INFO_MODEL_ID_1,
-    isPartOf = "http://localhost:5000/catalogs/$CATALOG_ID_1",
+    isPartOf = "http://localhost:5050/catalogs/$CATALOG_ID_1",
     issued = TEST_HARVEST_DATE.timeInMillis,
     modified = TEST_HARVEST_DATE.timeInMillis
 )
@@ -43,11 +43,11 @@ val CATALOG_DBO_2 = CatalogMeta(
 val INFO_MODEL_META_2 = InformationModelMeta(
     uri="https://raw.github.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#AltMuligModell",
     fdkId="0bf6b09f-e1c0-3415-bba0-7ff2edada89d",
-    isPartOf="http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444",
+    isPartOf="http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444",
     issued=1601903739831, modified=1601903739831)
 
 val INFO_MODEL_META_3 = InformationModelMeta(
     uri="https://raw.github.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Diversemodell",
     fdkId="bcbe6738-85f6-388c-afcc-ef1fafd7cc45",
-    isPartOf="http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444",
+    isPartOf="http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444",
     issued=1601903739831, modified=1601903739831)

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/TestData.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/TestData.kt
@@ -4,7 +4,7 @@ import no.fdk.fdk_informationmodel_harvester.model.HarvestDataSource
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap
 import java.util.*
 
-const val LOCAL_SERVER_PORT = 5000
+const val LOCAL_SERVER_PORT = 5050
 
 const val WIREMOCK_TEST_URI = "http://localhost:$LOCAL_SERVER_PORT"
 

--- a/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/jwk/JwtToken.kt
+++ b/src/test/kotlin/no/fdk/fdk_informationmodel_harvester/utils/jwk/JwtToken.kt
@@ -17,7 +17,7 @@ class JwtToken (private val access: Access) {
             .claim("name", "TEST USER")
             .claim("given_name", "TEST")
             .claim("family_name", "USER")
-            .claim("iss", "http://localhost:5000/auth/realms/fdk")
+            .claim("iss", "http://localhost:5050/auth/realms/fdk")
             .claim("authorities", access.authorities)
             .build()
 

--- a/src/test/resources/all_catalogs.ttl
+++ b/src/test/resources/all_catalogs.ttl
@@ -591,32 +591,32 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
       dct:title  "vegadresseSpesialiserer"^^xsd:string ;
       modelldcatno:hasGeneralConcept digdir:GeografiskAdresse .
 
-<http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
+<http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
         a                  dcat:CatalogRecord ;
         dct:identifier     "3edd0561-326b-303d-9dcb-1966ef7c63eb" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:Katalog1 .
 
-<http://localhost:5000/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
+<http://localhost:5050/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
         a                  dcat:CatalogRecord ;
         dct:identifier     "1f44a866-2cbd-3b80-bf72-cccb99965e25" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .
 
-<http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
+<http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
         a                  dcat:CatalogRecord ;
         dct:identifier     "e5b2ad5e-078b-3aea-af04-6051c2b0244b" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:Katalog0 .
 
-<http://localhost:5000/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
+<http://localhost:5050/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
         a                  dcat:CatalogRecord ;
         dct:identifier     "409c97dd-57e0-3a29-b5a3-023733cf5064" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:PersonOgEnhet .

--- a/src/test/resources/catalog_0.ttl
+++ b/src/test/resources/catalog_0.ttl
@@ -366,17 +366,17 @@ digdir:geografiskAdresseSpesialiserer a       owl:NamedIndividual , modelldcatno
         dct:title  "geografiskAdresseSpesialiserer"^^xsd:string ;
         modelldcatno:hasGeneralConcept digdir:Adresse .
 
-<http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
+<http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
         a                  dcat:CatalogRecord ;
         dct:identifier     "e5b2ad5e-078b-3aea-af04-6051c2b0244b" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:Katalog0 .
 
-<http://localhost:5000/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
+<http://localhost:5050/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
         a                  dcat:CatalogRecord ;
         dct:identifier     "409c97dd-57e0-3a29-b5a3-023733cf5064" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:PersonOgEnhet .

--- a/src/test/resources/catalog_0_catalog_diff.ttl
+++ b/src/test/resources/catalog_0_catalog_diff.ttl
@@ -366,17 +366,17 @@ digdir:geografiskAdresseSpesialiserer a       owl:NamedIndividual , modelldcatno
         dct:title  "geografiskAdresseSpesialiserer"^^xsd:string ;
         modelldcatno:hasGeneralConcept digdir:Adresse .
 
-<http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
+<http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
         a                  dcat:CatalogRecord ;
         dct:identifier     "e5b2ad5e-078b-3aea-af04-6051c2b0244b" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-15T11:52:16.122Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:Katalog0 .
 
-<http://localhost:5000/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
+<http://localhost:5050/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
         a                  dcat:CatalogRecord ;
         dct:identifier     "409c97dd-57e0-3a29-b5a3-023733cf5064" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:PersonOgEnhet .

--- a/src/test/resources/catalog_0_no_models.ttl
+++ b/src/test/resources/catalog_0_no_models.ttl
@@ -23,7 +23,7 @@ digdir:Utgiver  a       owl:NamedIndividual , foaf:Agent ;
         dct:type        "Organisasjonsledd"@nb ;
         foaf:name       "Digitaliseringsdirektoratet"@nb .
 
-<http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
+<http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
         a                  dcat:CatalogRecord ;
         dct:identifier     "e5b2ad5e-078b-3aea-af04-6051c2b0244b" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;

--- a/src/test/resources/catalog_1.ttl
+++ b/src/test/resources/catalog_1.ttl
@@ -270,17 +270,17 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
       dct:title  "vegadresseSpesialiserer"^^xsd:string ;
       modelldcatno:hasGeneralConcept digdir:GeografiskAdresse .
 
-<http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
+<http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
         a                  dcat:CatalogRecord ;
         dct:identifier     "3edd0561-326b-303d-9dcb-1966ef7c63eb" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:Katalog1 .
 
-<http://localhost:5000/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
+<http://localhost:5050/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
         a                  dcat:CatalogRecord ;
         dct:identifier     "1f44a866-2cbd-3b80-bf72-cccb99965e25" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .

--- a/src/test/resources/catalog_1_wrong_meta.ttl
+++ b/src/test/resources/catalog_1_wrong_meta.ttl
@@ -270,17 +270,17 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
       dct:title  "vegadresseSpesialiserer"^^xsd:string ;
       modelldcatno:hasGeneralConcept digdir:GeografiskAdresse .
 
-<http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
+<http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
         a                  dcat:CatalogRecord ;
         dct:identifier     "wrong-catalog-identifier" ;
         dct:issued         "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:Katalog1 .
 
-<http://localhost:5000/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
+<http://localhost:5050/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
         a                  dcat:CatalogRecord ;
         dct:identifier     "wrong-model-identifier" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
         dct:issued         "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .

--- a/src/test/resources/catalog_2.ttl
+++ b/src/test/resources/catalog_2.ttl
@@ -496,25 +496,25 @@ ex-rel:realisereksempel  a    owl:NamedIndividual ,
         xsd:maxOccurs               "1"^^xsd:int ;
         xsd:minOccurs               "0"^^xsd:int .
 
-<http://localhost:5000/informationmodels/0bf6b09f-e1c0-3415-bba0-7ff2edada89d>
+<http://localhost:5050/informationmodels/0bf6b09f-e1c0-3415-bba0-7ff2edada89d>
         a                  dcat:CatalogRecord ;
         dct:identifier     "0bf6b09f-e1c0-3415-bba0-7ff2edada89d" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digs:AltMuligModell .
 
-<http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444>
+<http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444>
         a                  dcat:CatalogRecord ;
         dct:identifier     "f25c939d-0722-3aa3-82b1-eaa457086444" ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digs:Katalog2 .
 
-<http://localhost:5000/informationmodels/bcbe6738-85f6-388c-afcc-ef1fafd7cc45>
+<http://localhost:5050/informationmodels/bcbe6738-85f6-388c-afcc-ef1fafd7cc45>
         a                  dcat:CatalogRecord ;
         dct:identifier     "bcbe6738-85f6-388c-afcc-ef1fafd7cc45" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digs:Diversemodell .

--- a/src/test/resources/model_0.ttl
+++ b/src/test/resources/model_0.ttl
@@ -366,3 +366,17 @@ digdir:geografiskAdresseSpesialiserer a       owl:NamedIndividual , modelldcatno
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:PersonOgEnhet .
+
+digdir:Katalog0  a        owl:NamedIndividual , dcat:Catalog ;
+        dct:description         "Katalog med oversikt over Digitaliseringsdirektoratets modeller"@nb ;
+        dct:identifier          "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog0"^^xsd:string ;
+        dct:publisher           digdir:Utgiver ;
+        dct:title               "Digitaliseringsdirektoratets modellkatalog 0"@nb ;
+        modelldcatno:model      digdir:PersonOgEnhet .
+
+<http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b>
+        a                  dcat:CatalogRecord ;
+        dct:identifier     "e5b2ad5e-078b-3aea-af04-6051c2b0244b" ;
+        dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        foaf:primaryTopic  digdir:Katalog0 .

--- a/src/test/resources/model_0.ttl
+++ b/src/test/resources/model_0.ttl
@@ -359,10 +359,10 @@ digdir:geografiskAdresseSpesialiserer a       owl:NamedIndividual , modelldcatno
         dct:title  "geografiskAdresseSpesialiserer"^^xsd:string ;
         modelldcatno:hasGeneralConcept digdir:Adresse .
 
-<http://localhost:5000/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
+<http://localhost:5050/informationmodels/409c97dd-57e0-3a29-b5a3-023733cf5064>
         a                  dcat:CatalogRecord ;
         dct:identifier     "409c97dd-57e0-3a29-b5a3-023733cf5064" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/e5b2ad5e-078b-3aea-af04-6051c2b0244b> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:PersonOgEnhet .

--- a/src/test/resources/model_1.ttl
+++ b/src/test/resources/model_1.ttl
@@ -270,3 +270,17 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .
+
+digdir:Katalog1  a        owl:NamedIndividual , dcat:Catalog ;
+        dct:description         "Katalog med oversikt over Digitaliseringsdirektoratets modeller"@nb ;
+        dct:identifier          "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog1"^^xsd:string ;
+        dct:publisher           digdir:Utgiver ;
+        dct:title               "Digitaliseringsdirektoratets modellkatalog 1"@nb ;
+        modelldcatno:model      digdir:AdresseModell .
+
+<http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
+        a                  dcat:CatalogRecord ;
+        dct:identifier     "3edd0561-326b-303d-9dcb-1966ef7c63eb" ;
+        dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        foaf:primaryTopic  digdir:Katalog1 .

--- a/src/test/resources/model_1.ttl
+++ b/src/test/resources/model_1.ttl
@@ -263,10 +263,10 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
       dct:title  "vegadresseSpesialiserer"^^xsd:string ;
       modelldcatno:hasGeneralConcept digdir:GeografiskAdresse .
 
-<http://localhost:5000/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
+<http://localhost:5050/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
         a                  dcat:CatalogRecord ;
         dct:identifier     "1f44a866-2cbd-3b80-bf72-cccb99965e25" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .

--- a/src/test/resources/model_1_wrong_meta.ttl
+++ b/src/test/resources/model_1_wrong_meta.ttl
@@ -270,3 +270,17 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
         dct:issued         "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .
+
+digdir:Katalog1  a        owl:NamedIndividual , dcat:Catalog ;
+        dct:description         "Katalog med oversikt over Digitaliseringsdirektoratets modeller"@nb ;
+        dct:identifier          "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog1"^^xsd:string ;
+        dct:publisher           digdir:Utgiver ;
+        dct:title               "Digitaliseringsdirektoratets modellkatalog 1"@nb ;
+        modelldcatno:model      digdir:AdresseModell .
+
+<http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb>
+        a                  dcat:CatalogRecord ;
+        dct:identifier     "wrong-catalog-identifier" ;
+        dct:issued         "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
+        dct:modified       "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
+        foaf:primaryTopic  digdir:Katalog1 .

--- a/src/test/resources/model_1_wrong_meta.ttl
+++ b/src/test/resources/model_1_wrong_meta.ttl
@@ -263,10 +263,10 @@ digdir:vegadresseSpesialiserer a       owl:NamedIndividual , modelldcatno:Specia
       dct:title  "vegadresseSpesialiserer"^^xsd:string ;
       modelldcatno:hasGeneralConcept digdir:GeografiskAdresse .
 
-<http://localhost:5000/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
+<http://localhost:5050/informationmodels/1f44a866-2cbd-3b80-bf72-cccb99965e25>
         a                  dcat:CatalogRecord ;
         dct:identifier     "wrong-model-identifier" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/3edd0561-326b-303d-9dcb-1966ef7c63eb> ;
         dct:issued         "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-11-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digdir:AdresseModell .

--- a/src/test/resources/model_2.ttl
+++ b/src/test/resources/model_2.ttl
@@ -65,10 +65,10 @@ ex-collection:Frukt  a  modelldcatno:ObjectType , owl:NamedIndividual ;
 ex-composition:nyre  a  modelldcatno:ObjectType , owl:NamedIndividual ;
         dct:title  "Nyre"@nb .
 
-<http://localhost:5000/informationmodels/0bf6b09f-e1c0-3415-bba0-7ff2edada89d>
+<http://localhost:5050/informationmodels/0bf6b09f-e1c0-3415-bba0-7ff2edada89d>
         a                  dcat:CatalogRecord ;
         dct:identifier     "0bf6b09f-e1c0-3415-bba0-7ff2edada89d" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digs:AltMuligModell .

--- a/src/test/resources/model_2.ttl
+++ b/src/test/resources/model_2.ttl
@@ -362,3 +362,26 @@ ex-note:merknad  a                  owl:NamedIndividual , modelldcatno:Role ;
 digs:Tidsintervall  a   dct:PeriodOfTime , owl:NamedIndividual ;
         dcat:endDate    "2030-02-11T00:00:00+01:00"^^xsd:dateTime ;
         dcat:startDate  "2016-02-11T00:00:00+01:00"^^xsd:dateTime .
+
+digs:Katalog2  a        owl:NamedIndividual , dcat:Catalog ;
+        dct:description         "Digdirs modelleksempler"@nb ;
+        dct:identifier          "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog"^^xsd:string ;
+        dct:publisher           <https://raw.github.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog2/.well-known/skolem/874c72cc-a8ac-3ea5-9d50-51e42a476804> ;
+        dct:license             <http://creativecommons.org/licenses/by/4.0/deed.no> ;
+        dct:title               "Digitaliseringsdirektoratets modellkatalog"@nb ;
+        modelldcatno:model      digs:AltMuligModell , digs:Diversemodell ;
+        dct:modified            "2017-09-28T00:00:00+01:00"^^xsd:dateTime ;
+        dct:spatial             <http://publications.europa.eu/resource/authority/country/NOR> .
+
+<https://raw.github.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog2/.well-known/skolem/874c72cc-a8ac-3ea5-9d50-51e42a476804>
+        a               foaf:Agent , owl:NamedIndividual ;
+        dct:identifier  "991825827" ;
+        dct:type        "Organisasjonsledd"@nb ;
+        foaf:name       "Digitaliseringsdirektoratet"@nb .
+
+<http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444>
+        a                  dcat:CatalogRecord ;
+        dct:identifier     "f25c939d-0722-3aa3-82b1-eaa457086444" ;
+        dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        foaf:primaryTopic  digs:Katalog2 .

--- a/src/test/resources/model_3.ttl
+++ b/src/test/resources/model_3.ttl
@@ -33,10 +33,10 @@ digs:Utgiver  a         foaf:Agent , owl:NamedIndividual ;
         dct:type        "Organisasjonsledd"@nb ;
         foaf:name       "Digitaliseringsdirektoratet"@nb .
 
-<http://localhost:5000/informationmodels/bcbe6738-85f6-388c-afcc-ef1fafd7cc45>
+<http://localhost:5050/informationmodels/bcbe6738-85f6-388c-afcc-ef1fafd7cc45>
         a                  dcat:CatalogRecord ;
         dct:identifier     "bcbe6738-85f6-388c-afcc-ef1fafd7cc45" ;
-        dct:isPartOf       <http://localhost:5000/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
+        dct:isPartOf       <http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444> ;
         dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
         foaf:primaryTopic  digs:Diversemodell .

--- a/src/test/resources/model_3.ttl
+++ b/src/test/resources/model_3.ttl
@@ -88,3 +88,26 @@ digs:KontaktOss  a          owl:NamedIndividual , vcard:Kind ;
         vcard:fn            "Avdeling for digitalisering"@nb , "Avdeling for digitalisering"@nn , "Digitalisation department"@en ;
         vcard:hasEmail      <mailto:informasjonsforvaltning@digdir.no> ;
         vcard:hasTelephone  <tel:12345678> .
+
+digs:Katalog2  a        owl:NamedIndividual , dcat:Catalog ;
+        dct:description         "Digdirs modelleksempler"@nb ;
+        dct:identifier          "https://raw.githubusercontent.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog"^^xsd:string ;
+        dct:publisher           <https://raw.github.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog2/.well-known/skolem/874c72cc-a8ac-3ea5-9d50-51e42a476804> ;
+        dct:license             <http://creativecommons.org/licenses/by/4.0/deed.no> ;
+        dct:title               "Digitaliseringsdirektoratets modellkatalog"@nb ;
+        modelldcatno:model      digs:AltMuligModell , digs:Diversemodell ;
+        dct:modified            "2017-09-28T00:00:00+01:00"^^xsd:dateTime ;
+        dct:spatial             <http://publications.europa.eu/resource/authority/country/NOR> .
+
+<https://raw.github.com/Informasjonsforvaltning/model-publisher/master/src/model/model-catalog.ttl#Katalog2/.well-known/skolem/874c72cc-a8ac-3ea5-9d50-51e42a476804>
+        a               foaf:Agent , owl:NamedIndividual ;
+        dct:identifier  "991825827" ;
+        dct:type        "Organisasjonsledd"@nb ;
+        foaf:name       "Digitaliseringsdirektoratet"@nb .
+
+<http://localhost:5050/catalogs/f25c939d-0722-3aa3-82b1-eaa457086444>
+        a                  dcat:CatalogRecord ;
+        dct:identifier     "f25c939d-0722-3aa3-82b1-eaa457086444" ;
+        dct:issued         "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        dct:modified       "2020-10-05T13:15:39.831Z"^^xsd:dateTime ;
+        foaf:primaryTopic  digs:Katalog2 .


### PR DESCRIPTION
resolve #143 

ref refaktoreringer:
- bytter wiremock-port siden mac bruker port 5000
- som det var så var det kode for å oppdatere meta-modellene i både InformationModelHarvester og UpdateService, fjernet det fra InformationModelHarvester og kjører heller oppdatering av meta-modellene via UpdateService etterpå. Dette er slik de andre høsterene opererer