### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   codeql:
     name: Run codeql scan

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   contents: read
-
+  security-events: write
 jobs:
   codeql:
     name: Run codeql scan


### PR DESCRIPTION
Potential fix for [https://github.com/Informasjonsforvaltning/fdk-informationmodel-harvester/security/code-scanning/8](https://github.com/Informasjonsforvaltning/fdk-informationmodel-harvester/security/code-scanning/8)

To fix the problem, explicitly declare a `permissions` block that limits the `GITHUB_TOKEN` to the least privilege required. Since this file simply triggers a reusable CodeQL workflow and does not itself perform write operations (such as pushing code, creating releases, or modifying issues), a conservative default of read‑only repository contents is appropriate.

The best fix with minimal behavioral impact is:

- Add a `permissions` block at the workflow root (top level, alongside `on` and `jobs`) so it applies to all jobs without modifying the reusable workflow call’s behavior.
- Use `contents: read` as a minimal starting point, which aligns with GitHub’s recommended baseline for read‑only workflows. If in the future additional scopes are needed, they can be added explicitly.

Concretely, in `.github/workflows/codeql.yaml`, insert:

```yaml
permissions:
  contents: read
  security-events: write
```

between the `on:` block (ending at line 12–13) and the `jobs:` block (starting at line 14). No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
